### PR TITLE
Adding chaos service url in ng-manager config

### DIFF
--- a/src/harness-manager/Chart.yaml
+++ b/src/harness-manager/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.47
+version: 0.2.48
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/harness-manager/templates/_helpers.tpl
+++ b/src/harness-manager/templates/_helpers.tpl
@@ -126,6 +126,9 @@ Create the name of the delegate upgrader image to use
 {{- if .Values.global.ng.enabled }}
 {{- $flags = printf "%s,%s" $flags .Values.featureFlags.NG }}
 {{- end }}
+{{- if .Values.global.chaos.enabled }}
+{{- $flags = printf "%s,%s" $flags .Values.featureFlags.CHAOS }}
+{{- end }}
 {{- $length2 := len .Values.featureFlags.ADDITIONAL }}
 {{- if gt $length2 0}}
 {{- $flags = printf "%s,%s" $flags .Values.featureFlags.ADDITIONAL }}

--- a/src/harness-manager/values.yaml
+++ b/src/harness-manager/values.yaml
@@ -35,6 +35,8 @@ global:
     enabled: false
   ngGitSync:
     enabled: false
+  chaos:
+    enabled: false
   useImmutableDelegate: "false"
 
 replicaCount: 1
@@ -188,5 +190,7 @@ featureFlags:
   LICENSE: "NG_LICENSES_ENABLED,VIEW_USAGE_ENABLED"
   # -- OPA
   OPA: "OPA_PIPELINE_GOVERNANCE,OPA_FEATURE_GOVERNANCE,OPA_FF_GOVERNANCE"
+  # -- CHAOS Feature Flags
+  CHAOS: "CHAOS_ENABLED"
   # -- Additional Feature Flag
   ADDITIONAL: ""

--- a/src/ng-manager/Chart.yaml
+++ b/src/ng-manager/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.29
+version: 0.2.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/ng-manager/templates/config.yaml
+++ b/src/ng-manager/templates/config.yaml
@@ -46,6 +46,7 @@ data:
   ACCESS_CONTROL_BASE_URL: 'http://access-control.{{ .Release.Namespace }}.svc.cluster.local:9006/api/'
   RESOURCE_GROUP_BASE_URL: 'http://platform-service.{{ .Release.Namespace }}.svc.cluster.local:9005/api/'
   AUDIT_CLIENT_BASEURL: 'http://platform-service.{{ .Release.Namespace }}.svc.cluster.local:9005/api/'
+  CHAOS_SERVICE_BASE_URL: http://chaos-web-service.{{ .Release.Namespace }}.svc.cluster.local:8184/
   CENG_CLIENT_BASEURL: 'http://nextgen-ce.{{ .Release.Namespace }}.svc.cluster.local:6340/ccm/api/'
   CE_NG_CLIENT_BASEURL: 'http://nextgen-ce.{{ .Release.Namespace }}.svc.cluster.local:6340/ccm/api/'
   CE_SETUP_CONFIG_GCP_PROJECT_ID: {{ .Values.ceGcpSetupConfigGcpProjectId | quote }}

--- a/src/platform/Chart.lock
+++ b/src/platform/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.2.7
 - name: harness-manager
   repository: file://../harness-manager
-  version: 0.2.47
+  version: 0.2.48
 - name: delegate-proxy
   repository: file://../delegate-proxy
   version: 0.2.7

--- a/src/platform/Chart.lock
+++ b/src/platform/Chart.lock
@@ -43,7 +43,7 @@ dependencies:
   version: 0.2.4
 - name: ng-manager
   repository: file://../ng-manager
-  version: 0.2.29
+  version: 0.2.30
 - name: pipeline-service
   repository: file://../pipeline-service
   version: 0.2.17

--- a/src/platform/Chart.yaml
+++ b/src/platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Adding `CHAOS_SERVICE_BASE_URL` in ng-manager config, as this variable is required for chaos and cd integration.
Signed-off-by: Adarsh kumar <adarsh.kumar@harness.io>