### PR TITLE
Disable secret flag in helm-platform

### DIFF
--- a/src/secrets/Chart.yaml
+++ b/src/secrets/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/src/secrets/templates/minio-secrets.yaml
+++ b/src/secrets/templates/minio-secrets.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.global.disableHarnessSecrets }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ metadata:
 type: Opaque
 data:
 {{- include "harnesssecrets.generateMinioSecrets" . }}
+{{ end }}

--- a/src/secrets/templates/secrets.yaml
+++ b/src/secrets/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{/* vim: set filetype=mustache: */}}
-
+{{ if not .Values.global.disableHarnessSecrets }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +10,5 @@ metadata:
 type: Opaque
 data:
 {{- include "harnesssecrets.generateSecrets" . }}
+{{ end }}
+

--- a/src/secrets/values.yaml
+++ b/src/secrets/values.yaml
@@ -1,4 +1,5 @@
 global:
+  disableHarnessSecrets: false
   ngcustomdashboard:
     enabled: true
 mongodb:


### PR DESCRIPTION
Description:

This PR adds an option to disable harness secrets in helm-platform chart.
Secrets can be disabled by changing flag to true in values.yaml

global:
  disableHarnessSecrets: true

Files changed:
[src/secrets/Chart.yaml]
[src/secrets/templates/minio-secrets.yaml]
[src/secrets/templates/secrets.yaml]

Testing:
Tested manifest locally by running:
helm template . -f test.yaml 

