### PR TITLE
[SMP-1341]: CORS changes for helm charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 charts/
+Chart.lock

--- a/src/harness-manager/Chart.yaml
+++ b/src/harness-manager/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.4.0
+version: 0.4.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/src/harness-manager/templates/config.yaml
+++ b/src/harness-manager/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations: {}
 data:
   GITOPS_SERVICE_CLIENT_BASEURL: http://gitops:7908/api/v1/
-  ALLOWED_ORIGINS: '{{  .Values.global.loadbalancerURL }}'
+  ALLOWED_ORIGINS: '{{ .Values.allowedOrigins | default .Values.global.loadbalancerURL }}'
   API_URL: '{{  .Values.global.loadbalancerURL }}'
   DELEGATE_METADATA_URL: '{{  .Values.global.loadbalancerURL }}/storage/wingsdelegates/delegateprod.txt'
   UI_SERVER_URL: '{{  .Values.global.loadbalancerURL }}'

--- a/src/harness-manager/values.yaml
+++ b/src/harness-manager/values.yaml
@@ -85,6 +85,8 @@ replicaCount: 1
 maxSurge: 1
 maxUnavailable: 0
 
+allowedOrigins: ""
+
 image:
   registry: docker.io
   repository: harness/manager-signed

--- a/src/ng-manager/Chart.lock
+++ b/src/ng-manager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: harness-common
   repository: https://harness.github.io/helm-common
-  version: 1.0.14
-digest: sha256:411eb35011d0f4ca9c0f98accc93a439658244d616a01771f3d10b2ea41257df
-generated: "2023-05-12T17:31:11.201875+05:30"
+  version: 1.0.15
+digest: sha256:35016c32c06ed98fd928106af6e51c30489ce7c24782e637c032045f8679afa2
+generated: "2023-05-24T10:17:44.145456+05:30"

--- a/src/ng-manager/Chart.yaml
+++ b/src/ng-manager/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 0.3.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/src/ng-manager/templates/config.yaml
+++ b/src/ng-manager/templates/config.yaml
@@ -72,7 +72,7 @@ data:
   PIPELINE_SERVICE_CLIENT_BASEURL: http://pipeline-service:12001/api/
   CI_MANAGER_SERVICE_CLIENT_BASEURL: http://ci-manager:7090/
   CVNG_SERVICE_CLIENT_BASEURL: http://cv-nextgen:6060/cv/api/
-  ALLOWED_ORIGINS: '{{ .Values.global.loadbalancerURL }}'
+  ALLOWED_ORIGINS: '{{ .Values.allowedOrigins | default .Values.global.loadbalancerURL }}'
   {{- if .Values.additionalConfigs }}
   {{- toYaml .Values.additionalConfigs | nindent 2 }}
   {{- end }}

--- a/src/ng-manager/templates/config.yaml
+++ b/src/ng-manager/templates/config.yaml
@@ -72,6 +72,7 @@ data:
   PIPELINE_SERVICE_CLIENT_BASEURL: http://pipeline-service:12001/api/
   CI_MANAGER_SERVICE_CLIENT_BASEURL: http://ci-manager:7090/
   CVNG_SERVICE_CLIENT_BASEURL: http://cv-nextgen:6060/cv/api/
+  ALLOWED_ORIGINS: '{{ .Values.global.loadbalancerURL }}'
   {{- if .Values.additionalConfigs }}
   {{- toYaml .Values.additionalConfigs | nindent 2 }}
   {{- end }}

--- a/src/ng-manager/values.yaml
+++ b/src/ng-manager/values.yaml
@@ -53,6 +53,8 @@ replicaCount: 1
 maxSurge: 1
 maxUnavailable: 0
 
+allowedOrigins: ""
+
 appLogLevel: "INFO"
 
 image:

--- a/src/pipeline-service/Chart.yaml
+++ b/src/pipeline-service/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/src/pipeline-service/templates/config.yaml
+++ b/src/pipeline-service/templates/config.yaml
@@ -62,7 +62,7 @@ data:
   ENABLE_AUDIT : 'true'
   AUDIT_SERVICE_BASE_URL: http://platform-service:9005/api/
   LOG_STREAMING_CONTAINER_STEP_BASE_URL: '{{ .Values.global.loadbalancerURL }}/log-service/'
-  ALLOWED_ORIGINS: '{{ .Values.global.loadbalancerURL }}'
+  ALLOWED_ORIGINS: '{{ .Values.allowedOrigins | default .Values.global.loadbalancerURL }}'
   {{- if .Values.additionalConfigs }}
   {{- toYaml .Values.additionalConfigs | nindent 2 }}
   {{- end }}

--- a/src/pipeline-service/templates/config.yaml
+++ b/src/pipeline-service/templates/config.yaml
@@ -62,6 +62,7 @@ data:
   ENABLE_AUDIT : 'true'
   AUDIT_SERVICE_BASE_URL: http://platform-service:9005/api/
   LOG_STREAMING_CONTAINER_STEP_BASE_URL: '{{ .Values.global.loadbalancerURL }}/log-service/'
+  ALLOWED_ORIGINS: '{{ .Values.global.loadbalancerURL }}'
   {{- if .Values.additionalConfigs }}
   {{- toYaml .Values.additionalConfigs | nindent 2 }}
   {{- end }}

--- a/src/pipeline-service/values.yaml
+++ b/src/pipeline-service/values.yaml
@@ -47,6 +47,8 @@ replicaCount: 1
 maxSurge: 1
 maxUnavailable: 0
 
+allowedOrigins: ""
+
 image:
   registry: docker.io
   digest: ""

--- a/src/platform/Chart.yaml
+++ b/src/platform/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.7.4
+version: 0.7.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/template-service/Chart.lock
+++ b/src/template-service/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: harness-common
   repository: https://harness.github.io/helm-common
-  version: 1.0.11
-digest: sha256:36d81c5d655cc0f30309f92732150b8458ca4e3592fa2ac8b0fec0904ab8062d
-generated: "2023-04-04T21:13:08.121218-04:00"
+  version: 1.0.15
+digest: sha256:35016c32c06ed98fd928106af6e51c30489ce7c24782e637c032045f8679afa2
+generated: "2023-05-24T10:24:55.337761+05:30"

--- a/src/template-service/Chart.yaml
+++ b/src/template-service/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/src/template-service/templates/config.yaml
+++ b/src/template-service/templates/config.yaml
@@ -33,7 +33,7 @@ data:
   PMS_GRPC_AUTHORITY: pipeline-service:12011
   PMS_GRPC_TARGET: pipeline-service:12011
   MANAGER_CLIENT_BASEURL: 'http://harness-manager:9090/api/'
-  ALLOWED_ORIGINS: '{{ .Values.global.loadbalancerURL }}'
+  ALLOWED_ORIGINS: '{{ .Values.allowedOrigins | default .Values.global.loadbalancerURL }}'
   {{- if .Values.additionalConfigs }}
   {{- toYaml .Values.additionalConfigs | nindent 2 }}
   {{- end }}

--- a/src/template-service/templates/config.yaml
+++ b/src/template-service/templates/config.yaml
@@ -33,6 +33,7 @@ data:
   PMS_GRPC_AUTHORITY: pipeline-service:12011
   PMS_GRPC_TARGET: pipeline-service:12011
   MANAGER_CLIENT_BASEURL: 'http://harness-manager:9090/api/'
+  ALLOWED_ORIGINS: '{{ .Values.global.loadbalancerURL }}'
   {{- if .Values.additionalConfigs }}
   {{- toYaml .Values.additionalConfigs | nindent 2 }}
   {{- end }}

--- a/src/template-service/values.yaml
+++ b/src/template-service/values.yaml
@@ -45,6 +45,8 @@ replicaCount: 1
 maxSurge: 1
 maxUnavailable: 0
 
+allowedOrigins: ""
+
 image:
   registry: docker.io
   repository: harness/template-service-signed


### PR DESCRIPTION
Extension to CORS fix: 
  ALLOWED_ORIGINS: '{{ .Values.allowedOrigins | default .Values.global.loadbalancerURL }}'
this is set because we can have multiple allowed origins, earlier we only used loadbalancerURL to be included as Access-Control-Allow-Origin hosts. This allowed placeholders for future use cases as well.
