### PR TITLE
SMP 1268: Remove cpu from resources.limits

### DIFF
--- a/src/access-control/values.yaml
+++ b/src/access-control/values.yaml
@@ -116,7 +116,6 @@ service:
 
 resources:
   limits:
-    cpu: 0.5
     memory: 8192Mi
   requests:
     cpu: 0.5

--- a/src/change-data-capture/values.yaml
+++ b/src/change-data-capture/values.yaml
@@ -138,7 +138,6 @@ service:
 
 resources:
   limits:
-    cpu: 1
     memory: 2880Mi
   requests:
     cpu: 1

--- a/src/cv-nextgen/values.yaml
+++ b/src/cv-nextgen/values.yaml
@@ -111,7 +111,6 @@ service:
 
 resources:
   limits:
-    cpu: 1
     memory: 6144Mi
   requests:
     cpu: 1

--- a/src/delegate-proxy/values.yaml
+++ b/src/delegate-proxy/values.yaml
@@ -46,7 +46,6 @@ service:
 
 resources:
   limits:
-    cpu: 200m
     memory: 100Mi
   requests:
     cpu: 200m

--- a/src/gateway/values.yaml
+++ b/src/gateway/values.yaml
@@ -109,7 +109,6 @@ service:
 
 resources:
   limits:
-    cpu: 0.4
     memory: 1024Mi
   requests:
     cpu: 0.2

--- a/src/harness-manager/values.yaml
+++ b/src/harness-manager/values.yaml
@@ -186,7 +186,6 @@ service:
 
 resources:
   limits:
-    cpu: 2
     memory: 8192Mi
   requests:
     cpu: 2

--- a/src/le-nextgen/values.yaml
+++ b/src/le-nextgen/values.yaml
@@ -47,7 +47,6 @@ service:
 
 resources:
   limits:
-    cpu: 1
     memory: 6144Mi
   requests:
     cpu: 1

--- a/src/learning-engine/values.yaml
+++ b/src/learning-engine/values.yaml
@@ -51,7 +51,6 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
-    cpu: 1
     memory: 2Gi
   requests:
     cpu: 1

--- a/src/log-service/values.yaml
+++ b/src/log-service/values.yaml
@@ -59,7 +59,6 @@ securityContext:
 
 resources:
   limits:
-    cpu: 1
     memory: 3072Mi
   requests:
     cpu: 1

--- a/src/migrator/values.yaml
+++ b/src/migrator/values.yaml
@@ -512,7 +512,6 @@ service:
 
 resources:
   limits:
-    cpu: 2
     memory: 8192Mi
   requests:
     cpu: 2

--- a/src/next-gen-ui/values.yaml
+++ b/src/next-gen-ui/values.yaml
@@ -84,7 +84,6 @@ service:
 
 resources:
   limits:
-    cpu: 0.2
     memory: 200Mi
   requests:
     cpu: 0.2

--- a/src/ng-auth-ui/values.yaml
+++ b/src/ng-auth-ui/values.yaml
@@ -56,7 +56,6 @@ containerPort: 8080
 
 resources:
   limits:
-    cpu: 0.5
     memory: 512Mi
   requests:
     cpu: 0.5

--- a/src/ng-manager/values.yaml
+++ b/src/ng-manager/values.yaml
@@ -177,7 +177,6 @@ service:
 
 resources:
   limits:
-    cpu: 2
     memory: 8192Mi
   requests:
     cpu: 2

--- a/src/pipeline-service/values.yaml
+++ b/src/pipeline-service/values.yaml
@@ -138,7 +138,6 @@ service:
 
 resources:
   limits:
-    cpu: 1
     memory: 6144Mi
   requests:
     cpu: 1

--- a/src/platform-service/values.yaml
+++ b/src/platform-service/values.yaml
@@ -111,7 +111,6 @@ service:
 
 resources:
   limits:
-    cpu: 0.5
     memory: 8192Mi
   requests:
     cpu: 0.5

--- a/src/platform/values.yaml
+++ b/src/platform/values.yaml
@@ -52,7 +52,6 @@ access-control:
   replicaCount: 1
   resources:
     limits:
-      cpu: 0.5
       memory: 8192Mi
     requests:
       cpu: 0.5
@@ -70,7 +69,6 @@ change-data-capture:
     memory: 2048
   resources:
     limits:
-      cpu: 1
       memory: 2880Mi
     requests:
       cpu: 1
@@ -87,7 +85,6 @@ cv-nextgen:
   replicaCount: 1
   resources:
     limits:
-      cpu: 1
       memory: 6144Mi
     requests:
       cpu: 1
@@ -101,7 +98,6 @@ delegate-proxy:
   replicaCount: 1
   resources:
     limits:
-      cpu: 200m
       memory: 100Mi
     requests:
       cpu: 200m
@@ -115,7 +111,6 @@ gateway:
   replicaCount: 1
   resources:
     limits:
-      cpu: 0.4
       memory: 1024Mi
     requests:
       cpu: 0.2
@@ -141,7 +136,6 @@ harness-manager:
   replicaCount: 1
   resources:
     limits:
-      cpu: 2
       memory: 8192Mi
     requests:
       cpu: 2
@@ -159,7 +153,6 @@ le-nextgen:
   replicaCount: 1
   resources:
     limits:
-      cpu: 1
       memory: 6144Mi
     requests:
       cpu: 1
@@ -173,7 +166,6 @@ learning-engine:
   replicaCount: 1
   resources:
     limits:
-      cpu: 1
       memory: 2048Mi
     requests:
       cpu: 1
@@ -185,7 +177,6 @@ log-service:
   replicaCount: 1
   resources:
     limits:
-      cpu: 1
       memory: 3072Mi
     requests:
       cpu: 1
@@ -211,7 +202,6 @@ migrator:
   replicaCount: 1
   resources:
     limits:
-      cpu: 2
       memory: 8192Mi
     requests:
       cpu: 2
@@ -245,7 +235,6 @@ mongodb:
   podLabels: { app: mongodb-replicaset }
   resources:
     limits:
-      cpu: 4
       memory: 8192Mi
     requests:
       cpu: 4
@@ -259,7 +248,6 @@ next-gen-ui:
   replicaCount: 1
   resources:
     limits:
-      cpu: 0.2
       memory: 200Mi
     requests:
       cpu: 0.2
@@ -273,7 +261,6 @@ ng-auth-ui:
   replicaCount: 1
   resources:
     limits:
-      cpu: 0.5
       memory: 512Mi
     requests:
       cpu: 0.5
@@ -290,7 +277,6 @@ ng-manager:
   replicaCount: 1
   resources:
     limits:
-      cpu: 2
       memory: 8192Mi
     requests:
       cpu: 2
@@ -307,7 +293,6 @@ pipeline-service:
   replicaCount: 1
   resources:
     limits:
-      cpu: 1
       memory: 6144Mi
     requests:
       cpu: 1
@@ -324,7 +309,6 @@ platform-service:
   replicaCount: 1
   resources:
     limits:
-      cpu: 0.5
       memory: 8192Mi
     requests:
       cpu: 0.5
@@ -341,7 +325,6 @@ redis:
   redis:
     resources:
       limits:
-        cpu: 0.1
         memory: 200Mi
       requests:
         cpu: 0.1
@@ -354,7 +337,6 @@ redis:
   sentinel:
     resources:
       limits:
-        cpu: 100m
         memory: 200Mi
       requests:
         cpu: 100m
@@ -377,7 +359,6 @@ scm-service:
   replicaCount: 1
   resources:
     limits:
-      cpu: 0.1
       memory: 512Mi
     requests:
       cpu: 0.1
@@ -394,7 +375,6 @@ template-service:
   replicaCount: 1
   resources:
     limits:
-      cpu: 1
       memory: 1400Mi
     requests:
       cpu: 1
@@ -408,7 +388,6 @@ ti-service:
     tag: "release-172"
   jobresources:
     limits:
-      cpu: 1
       memory: 3072Mi
     requests:
       cpu: 1
@@ -420,7 +399,6 @@ ti-service:
   replicaCount: 1
   resources:
     limits:
-      cpu: 1
       memory: 3072Mi
     requests:
       cpu: 1
@@ -435,7 +413,6 @@ timescaledb:
   replicaCount: 1
   resources:
     limits:
-      cpu: 1
       memory: 2048Mi
     requests:
       cpu: 1
@@ -452,7 +429,6 @@ ui:
   replicaCount: 1
   resources:
     limits:
-      cpu: 500m
       memory: 512Mi
     requests:
       cpu: 500m
@@ -469,7 +445,6 @@ verification-svc:
   replicaCount: 1
   resources:
     limits:
-      cpu: 500m
       memory: 3000Mi
     requests:
       cpu: 500m

--- a/src/scm-service/values.yaml
+++ b/src/scm-service/values.yaml
@@ -45,7 +45,6 @@ service:
 
 resources:
   limits:
-    cpu: 0.1
     memory: 512Mi
   requests:
     cpu: 0.1

--- a/src/template-service/values.yaml
+++ b/src/template-service/values.yaml
@@ -112,7 +112,6 @@ service:
 
 resources:
   limits:
-    cpu: 1
     memory: 1400Mi
   requests:
     cpu: 1

--- a/src/ti-service/values.yaml
+++ b/src/ti-service/values.yaml
@@ -119,7 +119,6 @@ service:
 
 resources:
   limits:
-    cpu: 1
     memory: 3072Mi
   requests:
     cpu: 1
@@ -127,7 +126,6 @@ resources:
 
 jobresources:
   limits:
-    cpu: 1
     memory: 3072Mi
   requests:
     cpu: 1

--- a/src/ui/values.yaml
+++ b/src/ui/values.yaml
@@ -84,7 +84,6 @@ service:
 
 resources:
   limits:
-    cpu: 500m
     memory: 512Mi
   requests:
     cpu: 500m

--- a/src/verification-svc/values.yaml
+++ b/src/verification-svc/values.yaml
@@ -130,7 +130,6 @@ service:
 
 resources:
   limits:
-    cpu: 500m
     memory: 3000Mi
   requests:
     cpu: 500m


### PR DESCRIPTION
As per best practices, utilizing requests.cpu and removing limits.cpu

Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)