### PR TITLE
feat: [OIP-498]: Make CVNG configs same as ng-prod-manifest

### DIFF
--- a/src/cv-nextgen/templates/deployment.yaml
+++ b/src/cv-nextgen/templates/deployment.yaml
@@ -64,13 +64,16 @@ spec:
               port: cv
             initialDelaySeconds: 60
             periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /cv/api/health
+              path: /cv/api/health/ping
               port: cv
             initialDelaySeconds: 300
-            periodSeconds: 10
-            failureThreshold: 2
+            timeoutSeconds: 10
+            periodSeconds: 60
+            failureThreshold: 5
           ports:
             - name: cv
               containerPort: {{.Values.service.port}}


### PR DESCRIPTION
Description:

Making the configuration for CVNG for SMP (on-prem) to be same as in ng-prod-manifest. This will prevent restarts like this : https://harness.atlassian.net/browse/OIP-498