### PR TITLE
[SMP-1419]: Add Mongo Connection URIs included in accesscontrol 791xx

### DIFF
--- a/src/access-control/templates/deployment.yaml
+++ b/src/access-control/templates/deployment.yaml
@@ -91,6 +91,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.mongoSecrets.password.name }}
                   key: {{ .Values.mongoSecrets.password.key }}
+            - name: MONGODB_CONNECTION_PROTOCOL
+              value: "mongodb://"
             {{- else }}
             - name: MONGODB_USER
               valueFrom:
@@ -102,6 +104,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.database.mongo.secretName }}
                   key: {{ .Values.global.database.mongo.passwordKey }}
+            - name: MONGODB_CONNECTION_PROTOCOL
+              value: '{{ .Values.global.database.mongo.protocol}}://'
             {{- end }}
             - name: MONGODB_HOSTS
               value: {{ include "access-control.mongohosts" . }}
@@ -109,6 +113,8 @@ spec:
               value: {{ include "harnesscommon.dbconnection.mongoConnection" (dict "database" "accesscontrol" "context" $) }}
             - name: OFFSET_STORAGE_FILE_FILENAME
               value: {{ include "harnesscommon.dbconnection.mongoConnection" (dict "database" "accesscontrol" "context" $) }}
+            - name: MONGODB_CONNECTION_URL
+              value: {{ include "access-control.mongoConnectionUrl" (dict "database" "accesscontrol" "context" $) }}
             - name: IDENTITY_SERVICE_SECRET
               value: 'HVSKUYqD4e5Rxu12hFDdCJKGM64sxgEynvdDhaOHaTHhwwn0K4Ttr0uoOxSsEVYNrUU='
           envFrom:

--- a/src/access-control/values.yaml
+++ b/src/access-control/values.yaml
@@ -22,16 +22,14 @@ global:
       ## - extra arguments set to connection string
       extraArgs: ""
     mongo:
-      installed: false
+      installed: true
       protocol: mongodb
       # --  provide default values if mongo.installed is set to false
-      hosts:
-      - h1
-      - h2
-      secretName: "xx"
-      userKey: "xx"
-      passwordKey: "xxx"
-      extraArgs: "xx"
+      hosts: []
+      secretName: ""
+      userKey: ""
+      passwordKey: ""
+      extraArgs: ""
     timescaledb:
       installed: true
       protocol: "jdbc:postgresql"


### PR DESCRIPTION
Please note that, although this includes addition of new helper function , It could be fixed by changing helm-common for this. However this configuration is temporary and will go away once debezium service is deprecated.